### PR TITLE
Fix IoU zero-division bug

### DIFF
--- a/atss.py
+++ b/atss.py
@@ -3,12 +3,16 @@ import cv2
 import numpy as np
 from bbox import BBoxBatch
 
-def compute_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Tensor:
-    """
-    Compute IoU between two sets of boxes.
-    boxes1: (N, 4) in x1,y1,x2,y2
-    boxes2: (M, 4) in x1,y1,x2,y2
-    returns IoU: (N, M)
+def compute_iou(boxes1: torch.Tensor, boxes2: torch.Tensor, eps: float = 1e-7) -> torch.Tensor:
+    """Compute IoU between two sets of boxes.
+
+    Args:
+        boxes1: (N, 4) boxes in ``x1, y1, x2, y2`` format.
+        boxes2: (M, 4) boxes in ``x1, y1, x2, y2`` format.
+        eps:    Small value added to the union to avoid division by zero.
+
+    Returns:
+        Tensor of shape ``(N, M)`` containing pairwise IoU values.
     """
     lt = torch.max(boxes1[:, None, :2], boxes2[None, :, :2])  # (N,M,2)
     rb = torch.min(boxes1[:, None, 2:], boxes2[None, :, 2:])  # (N,M,2)
@@ -18,4 +22,4 @@ def compute_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Tensor:
     area1 = (boxes1[:, 2] - boxes1[:, 0]) * (boxes1[:, 3] - boxes1[:, 1])  # (N,)
     area2 = (boxes2[:, 2] - boxes2[:, 0]) * (boxes2[:, 3] - boxes2[:, 1])  # (M,)
     union = area1[:, None] + area2[None, :] - inter
-    return inter / union
+    return inter / (union + eps)


### PR DESCRIPTION
## Summary
- avoid division by zero when computing IoU in `atss.compute_iou`
- document new `eps` argument

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685667f3fff0832584e275029d4ddcf3