### PR TITLE
Fix docstring typo in matrix_iof

### DIFF
--- a/data_augment.py
+++ b/data_augment.py
@@ -4,7 +4,8 @@ import random
 
 def matrix_iof(a, b):
     """
-    return iof of a and b, numpy version for data augenmentation
+    return iof of a and b, numpy version for data augmentation.
+
     """
     lt = np.maximum(a[:, np.newaxis, :2], b[:, :2])
     rb = np.minimum(a[:, np.newaxis, 2:], b[:, 2:])


### PR DESCRIPTION
## Summary
- correct spelling in `matrix_iof` docstring
- add newline for style

## Testing
- `python -m py_compile data_augment.py`

------
https://chatgpt.com/codex/tasks/task_e_685668da9430832592b2d5d7e253983d